### PR TITLE
Security: Hardcoded API Token in Configuration

### DIFF
--- a/Examples/hackathonProjects/resnet18_&_resnet34/dendritic_experiment/config.py
+++ b/Examples/hackathonProjects/resnet18_&_resnet34/dendritic_experiment/config.py
@@ -3,7 +3,7 @@ import os
 # PAI Credentials
 # User should fill these in or set environment variables
 PAI_EMAIL = os.getenv("PAIEMAIL", "hacker@perforatedai.com")
-PAI_TOKEN = os.getenv("PAITOKEN", "InJ9BjZSB+B+l30bmSzhqOwsXxOx0NRKAe8dtdAqdQcT/pKjmme1fqB1zrnCd5CWNrhJm40PVjaDbIrjR5xU+q2uhcUWX8gk2Kb2lHjafkUnizPXyP+yckbv+UxlU25ZlrvC3XlLu/AZdVKJE7Eov9+4c76sKe2hbRnH1fny2xIPYmy2/m/sY1gxXbhPtTa1mtxk2EgLeo5pRu/eL/7pSXWmEoRmvVorgQEJzt1VYOZyp0vP4bLxF72tOgSjXGBO8SHHcN16CbOVJuIEm3jmEc/AfPyyB+G4TEqhH7UZ0W2R/bnXtNberKqF2bQTuyT26etQw6NEMoXwuugDcrBXEw==")
+PAI_TOKEN = os.getenv("PAITOKEN")
 
 # Hyperparameters
 BATCH_SIZE = 128


### PR DESCRIPTION
## Summary

Security: Hardcoded API Token in Configuration

## Problem

**Severity**: `Critical` | **File**: `Examples/hackathonProjects/resnet18_&_resnet34/dendritic_experiment/config.py:L9`

The config.py file contains a hardcoded PerforatedAI API token in the PAI_TOKEN variable. This is a security risk as credentials should never be hardcoded in source code.

## Solution

Remove the hardcoded token value. Only use environment variables: PAI_TOKEN = os.getenv('PAITOKEN') and require users to set it via environment or secure config.

## Changes

- `Examples/hackathonProjects/resnet18_&_resnet34/dendritic_experiment/config.py` (modified)