### PR TITLE
add dendritron variant

### DIFF
--- a/dendrite_variants/README.md
+++ b/dendrite_variants/README.md
@@ -88,3 +88,8 @@ python mnist_perforatedai_variant.py --dataset EMNIST
 ```
 
 The `variant_framework/` directory contains the an example variant implementation which just implements dendrites as a simple linear layer using typical gradient descent as the local loss rule. See `variant_framework/README.md` for details on that specific variant.
+
+The `dendritron/` directory contains a routed specialist architecture that can
+replace linear dendrite candidates while leaving the active PerforatedAI
+training rule unchanged. See `dendritron/README.md` for installation, usage, and
+focused test instructions.

--- a/dendrite_variants/README.md
+++ b/dendrite_variants/README.md
@@ -83,11 +83,19 @@ Everything after this — optimizer setup, training loop, `add_extra_score`, `ad
 
 ```bash
 cd dendrite_variants
-python mnist_perforatedai_variant.py
-python mnist_perforatedai_variant.py --dataset EMNIST
+python mnist_perforatedai_variant.py --variant variant_framework
+python mnist_perforatedai_variant.py --variant dendritron
 ```
 
 The `variant_framework/` directory contains the an example variant implementation which just implements dendrites as a simple linear layer using typical gradient descent as the local loss rule. See `variant_framework/README.md` for details on that specific variant.
+
+---
+
+## Contributing Your Variant
+
+**If your variant works on Linear or Conv2d modules**, please add your variant to the MNIST example by creating a new branch in the variant selection logic. This makes it easy for others to test and compare variants.
+
+**If your variant works on any other types of module** as the neuron module, please create a new minimal simple example use case that demonstrates your variant's capabilities. This helps keep the MNIST example focused while showcasing the flexibility of the variant framework.
 
 ## Included Dendritron variant
 

--- a/dendrite_variants/README.md
+++ b/dendrite_variants/README.md
@@ -89,7 +89,22 @@ python mnist_perforatedai_variant.py --dataset EMNIST
 
 The `variant_framework/` directory contains the an example variant implementation which just implements dendrites as a simple linear layer using typical gradient descent as the local loss rule. See `variant_framework/README.md` for details on that specific variant.
 
-The `dendritron/` directory contains a routed specialist architecture that can
-replace linear dendrite candidates while leaving the active PerforatedAI
-training rule unchanged. See `dendritron/README.md` for installation, usage, and
-focused test instructions.
+## Included Dendritron variant
+
+The `dendritron/` directory contains an architecture-only variant for
+`nn.Linear` parents. Each PerforatedAI candidate becomes a residual, top-k
+routed mixture of specialist networks while the platform retains control of the
+candidate lifecycle, learning rule, acceptance, and restructuring.
+
+The Dendritron guide explains:
+
+- the difference between a parent module, candidate, specialist branch, and
+  accepted dendrite;
+- the exact forward path and current sparse-routing limitations;
+- installation and package naming;
+- lifecycle-safe integration, including optimizer rebuilds after restructuring;
+- configuration, routing diagnostics, verification, troubleshooting, and the
+  scope of the current test evidence.
+
+See [`dendritron/README.md`](dendritron/README.md) before integrating the variant
+into a training pipeline.

--- a/dendrite_variants/dendritron/README.md
+++ b/dendrite_variants/dendritron/README.md
@@ -39,6 +39,17 @@ Package naming is intentionally different in three places:
 Do not commit Perforated Backpropagation credentials. Supply any licensed-package
 credentials through the environment as directed by PerforatedAI.
 
+For licensed Perforated Backpropagation testing, install the current package in
+the same environment:
+
+```bash
+python -m pip install --upgrade perforatedbp
+```
+
+The full N -> P -> N lifecycle was tested with `perforatedbp==3.2.5`. Older
+releases may not contain the dendrite-variant registration API used by the
+current `develop` branch.
+
 ## Add the variant to a training script
 
 Configure linear-only perforation, wrap the model, and then initialize the

--- a/dendrite_variants/dendritron/README.md
+++ b/dendrite_variants/dendritron/README.md
@@ -1,0 +1,92 @@
+# Dendritron Variant
+
+This directory provides a Dendritron candidate architecture for PerforatedAI.
+Each candidate uses four specialist branches by default, a learned top-2 sparse
+router, a post-projection, a residual path, and GELU activation.
+
+The variant changes candidate architecture only. It deliberately does not
+replace PerforatedAI's learning rule or epoch scoring:
+
+- with the open-source `perforatedai` package, candidates use the platform's
+  standard gradient-descent path;
+- when the separately licensed `perforatedbp` package is installed and enabled,
+  candidates use its configured Perforated Backpropagation learning rule.
+
+## Install from the contribution branch
+
+```bash
+git clone https://github.com/RichardAragon/PerforatedAI.git
+cd PerforatedAI
+git checkout agent/add-dendritron-variant
+python -m pip install -e .
+```
+
+After this contribution is merged, replace the checkout command with
+`git checkout develop` when testing the development branch.
+
+Run scripts that import this repository-only variant from the checkout root (or
+add that root to `PYTHONPATH`). The editable install exposes the published
+`perforatedai` library; the `dendrite_variants/` examples are intentionally not
+part of the PyPI package.
+
+Package naming is intentionally different in three places:
+
+- PyPI distribution and Python import: `perforatedai`
+- optional Perforated Backpropagation distribution and import: `perforatedbp`
+- this repository-only variant module:
+  `dendrite_variants.dendritron.dendritron`
+
+Do not commit Perforated Backpropagation credentials. Supply any licensed-package
+credentials through the environment as directed by PerforatedAI.
+
+## Add the variant to a training script
+
+Configure linear-only perforation, wrap the model, and then initialize the
+variant:
+
+```python
+from perforatedai import globals_perforatedai as GPA
+from perforatedai import utils_perforatedai as UPA
+
+GPA.pc.set_module_names_to_perforate(["Linear"])
+model = UPA.perforate_model(model)
+
+from dendrite_variants.dendritron import dendritron
+
+dendritron.initialize_variant_dendrite()
+```
+
+Optional constructor settings can be supplied during initialization:
+
+```python
+dendritron.initialize_variant_dendrite(
+    branches=4,
+    top_k=2,
+    hidden_features=None,  # defaults to max(in_features, out_features)
+)
+```
+
+`initialize_variant_dendrite` must be called after `perforate_model`, because it
+registers the candidate factory on the tracked modules created during
+perforation. The remainder of the optimizer, training, and validation pipeline
+is unchanged.
+
+## Architecture contract
+
+`create_dendritron_dendrite(parent)` accepts an `nn.Linear` and returns an
+`nn.Module` with matching input and output dimensions. Non-square linears use a
+learned residual projection; square linears use an identity residual. The
+implementation preserves all leading tensor dimensions, including sequence or
+spatially grouped inputs ending in `in_features`.
+
+The factory also accepts an existing `DendritronLinear`. PerforatedAI uses that
+path when it creates the best-candidate copy, so both candidate modules have the
+same Dendritron configuration.
+
+## Focused test
+
+From the repository root:
+
+```bash
+python -m unittest dendrite_variants.dendritron.test_dendritron
+```

--- a/dendrite_variants/dendritron/README.md
+++ b/dendrite_variants/dendritron/README.md
@@ -1,18 +1,170 @@
 # Dendritron Variant
 
-This directory provides a Dendritron candidate architecture for PerforatedAI.
-Each candidate uses four specialist branches by default, a learned top-2 sparse
-router, a post-projection, a residual path, and GELU activation.
+The Dendritron variant changes the architecture of the temporary dendrite
+candidates that PerforatedAI creates for `torch.nn.Linear` layers. A Dendritron
+is a residual, routed mixture of small specialist networks. The router selects
+which specialists contribute to each input, while PerforatedAI continues to
+control when candidates are created, how they are trained, and whether they are
+retained as permanent dendrites.
 
-The variant changes candidate architecture only. It deliberately does not
-replace PerforatedAI's learning rule or epoch scoring:
+This is an architecture-only variant. It does not replace PerforatedAI's
+training lifecycle, validation logic, optimizer integration, or the selected
+learning rule.
 
-- with the open-source `perforatedai` package, candidates use the platform's
-  standard gradient-descent path;
-- when the separately licensed `perforatedbp` package is installed and enabled,
-  candidates use its configured Perforated Backpropagation learning rule.
+## Start here: the three levels of terminology
 
-## Install from the contribution branch
+These terms refer to different objects:
+
+- **Parent module:** an existing `nn.Linear` in the user's model. PerforatedAI
+  wraps it and continues to compute its normal output.
+- **Dendrite candidate:** a temporary module that PerforatedAI creates and
+  evaluates for a wrapped parent. With this variant registered, that temporary
+  module is a `DendritronLinear` rather than a deep copy of the parent linear.
+- **Specialist branch:** one of the internal expert networks inside a single
+  `DendritronLinear`. The router mixes `top_k` of these specialists for each
+  input position.
+- **Accepted dendrite:** a candidate that PerforatedAI copies into the wrapped
+  module's persistent dendrite collection. PerforatedAI combines accepted
+  dendrite outputs with the parent module's output using platform-managed
+  connections.
+
+In short, one PerforatedAI dendrite candidate contains several Dendritron
+specialist branches. A specialist branch is not itself a PerforatedAI dendrite.
+
+## What changes and what stays the same
+
+The variant changes only this factory decision:
+
+```text
+Default candidate factory:     parent nn.Linear -> copied nn.Linear candidate
+Dendritron candidate factory:  parent nn.Linear -> DendritronLinear candidate
+```
+
+It does not automatically change:
+
+- the user's model definition, dataset, task loss, or validation metric;
+- which modules PerforatedAI wraps;
+- the PerforatedAI N/P training-cycle decisions;
+- candidate acceptance and model restructuring;
+- the optimizer or scheduler lifecycle;
+- Perforated Backpropagation's local loss or epoch scoring function.
+
+With the open-source `perforatedai` package, the platform uses its standard
+gradient-descent candidate path. When the separately licensed `perforatedbp`
+package is installed and enabled, the same Dendritron candidate architecture is
+trained by the configured Perforated Backpropagation rule.
+
+## Why this candidate architecture exists
+
+A copied linear candidate applies one learned affine transformation to every
+input. A Dendritron candidate tests a different capacity hypothesis: inputs may
+benefit from different nonlinear transformations, and a learned router may be
+able to select and combine those transformations locally.
+
+The specialist branches provide alternative transformations. The router makes
+their use input-dependent. The residual path preserves a direct route from the
+candidate input to its output, while the post-projection lets the mixed
+specialist representation be recombined before the final activation.
+
+This makes a Dendritron a richer candidate than a copied `nn.Linear`, but richer
+also means more parameters and compute. The architecture is offered so that the
+hypothesis can be measured inside PerforatedAI's normal candidate-selection
+process. Its inclusion is not evidence that it will outperform a linear
+candidate on every task.
+
+## Architecture and data flow
+
+For an input whose last dimension is `in_features`, a `DendritronLinear` follows
+this path:
+
+```text
+input (..., in_features)
+  |
+  +-- router: Linear(in_features, branches) -> softmax -> top-k weights
+  |
+  +-- specialist 0: Linear(in, hidden) -> GELU -> Linear(hidden, out) --+
+  +-- specialist 1: Linear(in, hidden) -> GELU -> Linear(hidden, out) --+-- weighted mixture
+  +-- ...                                                               |
+  +-- specialist B-1                                                    |
+  |                                                                     v
+  |                                                        post-projection Linear(out, out)
+  |
+  +-- residual: Identity when in == out, otherwise Linear(in, out)
+                                                                        |
+                  GELU(post-projection(mixture) + residual) <-----------+
+                                    |
+                                    v
+                         output (..., out_features)
+```
+
+Routing happens independently at every input position. For example, an input
+with shape `[batch, tokens, features]` receives one specialist selection per
+`[batch, token]` position. All leading dimensions are preserved.
+
+The router first produces a probability for every specialist. It keeps the
+largest `top_k` probabilities, sets the remaining mixture weights to zero, and
+renormalizes the selected weights. Only selected specialist outputs contribute
+to the mixture.
+
+Important: the current reference implementation evaluates every specialist
+before applying the sparse mixture. The routing is sparse in contribution and
+branch gradient flow, but it is not yet a sparse-compute implementation and
+should not be expected to reduce inference latency.
+
+### Concrete shape example
+
+Suppose the parent is `nn.Linear(128, 64)` and the Dendritron uses its default
+`branches=4`, `top_k=2`, and `hidden_features=128`. For an input batch shaped
+`[32, 128]`:
+
+1. The router produces `[32, 4]` probabilities.
+2. Exactly two mixture weights per row remain nonzero after top-k selection.
+3. Each specialist produces a `[32, 64]` output.
+4. The four specialist outputs are stacked as `[32, 4, 64]` and reduced with
+   the sparse weights to `[32, 64]`.
+5. The post-projection preserves `[32, 64]`.
+6. Because the parent is non-square, a learned residual projection maps the
+   input from `[32, 128]` to `[32, 64]`.
+7. The projected mixture and residual are added and passed through GELU,
+   producing the required `[32, 64]` candidate output.
+
+## How it participates in the PerforatedAI lifecycle
+
+Registering the variant does not immediately insert a Dendritron into the
+model. It installs a candidate factory for future dendrite cycles:
+
+1. Configure PerforatedAI and select `Linear` for perforation.
+2. Call `UPA.perforate_model(model)` to wrap the selected parent modules.
+3. Call `dendritron.initialize_variant_dendrite(...)` to register the factory on
+   those wrappers.
+4. Normal or **N mode** trains/evaluates the current model.
+5. When PerforatedAI enters candidate or **P mode**, it asks the registered
+   factory to create a `DendritronLinear` for each eligible wrapped layer.
+6. The active learning rule trains the temporary candidate.
+7. When PerforatedAI returns to N mode, the platform retains the selected best
+   candidate as an accepted dendrite and restructures the model.
+8. The optimizer and scheduler must be rebuilt for the returned model whenever
+   `add_validation_score` reports `restructured=True`.
+
+The platform may repeat this process, allowing a wrapped parent to accumulate
+more than one accepted Dendritron over successive cycles.
+
+## Requirements and supported scope
+
+- Python environment capable of running the current PerforatedAI `develop`
+  branch
+- PyTorch and the `perforatedai` package from this repository
+- `nn.Linear` parent modules only
+- inputs whose last dimension equals the parent's `in_features`
+- optional licensed `perforatedbp` for Perforated Backpropagation training
+
+Convolutional, recurrent, attention, and arbitrary custom parent modules are not
+accepted by this factory. They can still be tracked by PerforatedAI, but they
+must not be selected for Dendritron perforation.
+
+## Installation
+
+### Test the contribution branch before merge
 
 ```bash
 git clone https://github.com/RichardAragon/PerforatedAI.git
@@ -21,23 +173,29 @@ git checkout agent/add-dendritron-variant
 python -m pip install -e .
 ```
 
-After this contribution is merged, replace the checkout command with
-`git checkout develop` when testing the development branch.
+### Test `develop` after merge
 
-Run scripts that import this repository-only variant from the checkout root (or
-add that root to `PYTHONPATH`). The editable install exposes the published
-`perforatedai` library; the `dendrite_variants/` examples are intentionally not
-part of the PyPI package.
+```bash
+git clone https://github.com/PerforatedAI/PerforatedAI.git
+cd PerforatedAI
+git checkout develop
+python -m pip install -e .
+```
 
-Package naming is intentionally different in three places:
+Run scripts that import this variant from the repository root, or add the
+repository root to `PYTHONPATH`. The editable install exposes the published
+`perforatedai` library; the `dendrite_variants/` examples are intentionally
+repository-only and are not installed as a top-level PyPI package.
 
-- PyPI distribution and Python import: `perforatedai`
-- optional Perforated Backpropagation distribution and import: `perforatedbp`
-- this repository-only variant module:
-  `dendrite_variants.dendritron.dendritron`
+### Package and import names
 
-Do not commit Perforated Backpropagation credentials. Supply any licensed-package
-credentials through the environment as directed by PerforatedAI.
+The related names are similar but not interchangeable:
+
+| Purpose | Install name | Python import |
+| --- | --- | --- |
+| Open-source platform | `perforatedai` | `perforatedai` |
+| Licensed learning-rule package | `perforatedbp` | `perforatedbp` |
+| Repository-only Dendritron variant | not separately installed | `dendrite_variants.dendritron` |
 
 For licensed Perforated Backpropagation testing, install the current package in
 the same environment:
@@ -48,56 +206,236 @@ python -m pip install --upgrade perforatedbp
 
 The full N -> P -> N lifecycle was tested with `perforatedbp==3.2.5`. Older
 releases may not contain the dendrite-variant registration API used by the
-current `develop` branch.
+current `develop` branch. Supply licensed-package credentials through the
+environment as directed by PerforatedAI; never commit them to source files,
+shell scripts, notebooks, logs, or configuration files.
 
-## Add the variant to a training script
+## Minimal integration
 
-Configure linear-only perforation, wrap the model, and then initialize the
-variant:
+Configure the supported parent type before wrapping the model. Register the
+variant only after `perforate_model`:
 
 ```python
 from perforatedai import globals_perforatedai as GPA
 from perforatedai import utils_perforatedai as UPA
-
-GPA.pc.set_module_names_to_perforate(["Linear"])
-model = UPA.perforate_model(model)
-
 from dendrite_variants.dendritron import dendritron
 
-dendritron.initialize_variant_dendrite()
+# Dendritron candidates currently support nn.Linear parents only.
+GPA.pc.set_module_names_to_perforate(["Linear"])
+
+# Convolutions may be tracked without receiving Dendritron candidates.
+GPA.pc.set_module_names_to_track(["Conv2d"])
+
+model = UPA.perforate_model(model)
+
+# This must follow perforate_model so the factory reaches the created wrappers.
+dendritron.initialize_variant_dendrite(
+    branches=4,
+    top_k=2,
+    hidden_features=None,
+)
 ```
 
-Optional constructor settings can be supplied during initialization:
+Everything else remains a normal PerforatedAI pipeline. In particular, keep the
+model returned by `add_validation_score` and rebuild the optimizer when the
+model is restructured:
+
+```python
+import torch.optim as optim
+from torch.optim.lr_scheduler import StepLR
+
+GPA.pai_tracker.set_optimizer(optim.Adadelta)
+GPA.pai_tracker.set_scheduler(StepLR)
+
+optimizer_args = {"params": model.parameters(), "lr": 1.0}
+scheduler_args = {"step_size": 1, "gamma": 0.7}
+optimizer, scheduler = GPA.pai_tracker.setup_optimizer(
+    model, optimizer_args, scheduler_args
+)
+
+for epoch in range(1, max_epochs + 1):
+    train_one_epoch(model, train_loader, optimizer)
+    validation_accuracy = evaluate_accuracy(model, validation_loader)
+
+    model, restructured, training_complete = (
+        GPA.pai_tracker.add_validation_score(validation_accuracy, model)
+    )
+    model.to(device)
+
+    if restructured:
+        optimizer_args = {"params": model.parameters(), "lr": 1.0}
+        optimizer, scheduler = GPA.pai_tracker.setup_optimizer(
+            model, optimizer_args, scheduler_args
+        )
+
+    if training_complete:
+        break
+```
+
+`train_one_epoch` and `evaluate_accuracy` above stand for the application's
+existing training and validation functions. Do not call `perforate_model` again
+inside the epoch loop.
+
+## Configuration reference
 
 ```python
 dendritron.initialize_variant_dendrite(
     branches=4,
     top_k=2,
-    hidden_features=None,  # defaults to max(in_features, out_features)
+    hidden_features=None,
 )
 ```
 
-`initialize_variant_dendrite` must be called after `perforate_model`, because it
-registers the candidate factory on the tracked modules created during
-perforation. The remainder of the optimizer, training, and validation pipeline
-is unchanged.
+| Argument | Meaning | Default | Tradeoff |
+| --- | --- | --- | --- |
+| `branches` | Number of internal specialist networks | `4` | More branches increase capacity, parameters, and compute. Must be at least 1. |
+| `top_k` | Specialists with nonzero mixture weight per input position | `2` | Lower values make routing more selective. Must be between 1 and `branches`. |
+| `hidden_features` | Width of each specialist's hidden layer | `max(in_features, out_features)` | Larger values increase specialist capacity and memory. Must be positive. |
 
-## Architecture contract
+The candidate mirrors whether the parent `nn.Linear` uses a bias, and it is
+created on the parent's device and dtype. If `in_features == out_features`, the
+residual path is an identity. Otherwise, the residual path is a learned,
+bias-free linear projection.
 
-`create_dendritron_dendrite(parent)` accepts an `nn.Linear` and returns an
-`nn.Module` with matching input and output dimensions. Non-square linears use a
-learned residual projection; square linears use an identity residual. The
-implementation preserves all leading tensor dimensions, including sequence or
-spatially grouped inputs ending in `in_features`.
+## Diagnostics and optional routing utilities
 
-The factory also accepts an existing `DendritronLinear`. PerforatedAI uses that
-path when it creates the best-candidate copy, so both candidate modules have the
-same Dendritron configuration.
+After a Dendritron has completed at least one forward pass, inspect its most
+recent routing behavior:
 
-## Focused test
+```python
+from dendrite_variants.dendritron.dendritron import DendritronLinear
 
-From the repository root:
+for name, module in model.named_modules():
+    if isinstance(module, DendritronLinear):
+        print(name, module.routing_metrics())
+        active = (module.last_sparse_weights > 0).sum(dim=-1)
+        print("active specialists per input:", active.unique().tolist())
+```
+
+`routing_metrics()` returns:
+
+- `router_entropy`: mean entropy of the router's soft probabilities;
+- `min_branch_utilization`: lowest mean soft probability among specialists;
+- `max_branch_utilization`: highest mean soft probability among specialists.
+
+These are diagnostics, not acceptance scores used by PerforatedAI.
+
+`DendritronLinear.balance_loss()` returns a differentiable penalty for unequal
+soft branch usage. The architecture-only integration does not add that penalty
+to the task loss or the Perforated Backpropagation local loss. Doing so would
+change the learning rule and should be treated as a separate, explicitly tested
+variant rather than silently enabled here.
+
+## How to verify that Dendritrons are actually being created
+
+Immediately after `initialize_variant_dendrite`, the count may still be zero
+because the function registers a factory; it does not create candidates. Check
+during P mode or after the first accepted-dendrite cycle:
+
+```python
+from dendrite_variants.dendritron.dendritron import DendritronLinear
+
+dendritrons = [
+    (name, module)
+    for name, module in model.named_modules()
+    if isinstance(module, DendritronLinear)
+]
+print("Dendritron modules:", [name for name, _ in dendritrons])
+```
+
+The focused unit tests can be run from the repository root:
 
 ```bash
 python -m unittest dendrite_variants.dendritron.test_dendritron
 ```
+
+They cover shape preservation, gradients, top-k routing, non-square residuals,
+candidate recreation, global registration, checkpoint reconstruction, and
+invalid configuration.
+
+## Troubleshooting
+
+### `TypeError: ... expected nn.Linear or DendritronLinear`
+
+An unsupported parent type was selected for perforation. Call
+`GPA.pc.set_module_names_to_perforate(["Linear"])` before `perforate_model` and
+track other module types separately if needed.
+
+### No `DendritronLinear` appears immediately after initialization
+
+This is expected. Initialization registers the factory. PerforatedAI calls it
+when the model enters a dendrite-candidate cycle. Continue through validation
+and model restructuring, then inspect the model during P mode or after a
+candidate has been accepted.
+
+### Candidates are ordinary `nn.Linear` modules
+
+Confirm that `initialize_variant_dendrite` is called after `perforate_model` and
+that the checkout includes the factory-persistence fix in this contribution.
+That fix preserves the registered factory when PerforatedAI reconstructs a
+wrapped module from saved state.
+
+### `ModuleNotFoundError: dendrite_variants`
+
+Run the script from the repository root or add that root to `PYTHONPATH`.
+Installing `perforatedai` from PyPI alone does not install this repository-only
+example directory.
+
+### Licensed PBP reports missing variant attributes
+
+Upgrade the licensed package in the same Python environment:
+
+```bash
+python -m pip install --upgrade perforatedbp
+```
+
+Version `3.2.5` was used for the documented full-cycle test.
+
+### Training stops updating after restructuring
+
+Always retain the model returned by `add_validation_score`. When
+`restructured=True`, rebuild the optimizer and scheduler against that returned
+model's parameters, as shown in the integration example.
+
+### One specialist dominates the router
+
+Inspect `routing_metrics()` over representative batches. `balance_loss()` is
+available for experiments, but it is intentionally not applied by this
+architecture-only variant. Any routing regularizer requires its own controlled
+benchmark because it changes the optimization objective.
+
+### Expected speedup does not appear
+
+The current implementation computes all specialist outputs and sparsifies only
+their mixture. It is a reference architecture for testing routed specialist
+geometry inside PerforatedAI, not a fused or conditional-execution kernel.
+
+## Validation scope and current evidence
+
+The contribution has been checked in three ways:
+
+- focused unit tests for the module and factory contract;
+- an open-source PerforatedAI lifecycle smoke test that created both candidate
+  and best-candidate `DendritronLinear` modules;
+- a licensed `perforatedbp==3.2.5` synthetic lifecycle test that completed
+  N -> P -> N, preserved the factory through reconstruction, changed candidate
+  parameters, retained Dendritron candidate types, and reached
+  `training_complete`.
+
+The licensed run validates integration mechanics on synthetic data. It is not a
+claim that this architecture improves accuracy, convergence, memory use, or
+training speed on a production dataset. Those questions require controlled
+task-specific benchmarks against the same model, data split, seeds, training
+budget, and acceptance settings.
+
+## API summary
+
+- `DendritronLinear(...)`: the routed specialist candidate module.
+- `create_dendritron_dendrite(parent, ...)`: factory accepting `nn.Linear` or an
+  existing `DendritronLinear` and returning a fresh compatible candidate.
+- `initialize_variant_dendrite(...)`: registers the configured factory globally
+  on the currently perforated modules; call it after `perforate_model`.
+- `DendritronLinear.routing_metrics()`: detached diagnostics from the latest
+  forward pass.
+- `DendritronLinear.balance_loss()`: optional differentiable branch-usage
+  regularizer that is not automatically added to any training objective.

--- a/dendrite_variants/dendritron/__init__.py
+++ b/dendrite_variants/dendritron/__init__.py
@@ -1,0 +1,13 @@
+"""Public exports for the Dendritron dendrite variant."""
+
+from .dendritron import (
+    DendritronLinear,
+    create_dendritron_dendrite,
+    initialize_variant_dendrite,
+)
+
+__all__ = [
+    "DendritronLinear",
+    "create_dendritron_dendrite",
+    "initialize_variant_dendrite",
+]

--- a/dendrite_variants/dendritron/dendritron.py
+++ b/dendrite_variants/dendritron/dendritron.py
@@ -1,0 +1,174 @@
+"""A sparse, routed Dendritron candidate for PerforatedAI.
+
+This variant changes only the candidate architecture. PerforatedAI therefore
+continues to choose the learning rule: standard gradient descent in the open
+source package, or the configured Perforated Backpropagation rule when that
+separate package is enabled.
+"""
+
+from __future__ import print_function
+
+from functools import partial
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from perforatedai import globals_perforatedai as GPA
+
+
+class DendritronLinear(nn.Module):
+    """Shape-preserving replacement for an ``nn.Linear`` dendrite candidate.
+
+    A learned router selects ``top_k`` specialist branches for each input. The
+    selected outputs are mixed, projected, combined with a residual path, and
+    passed through GELU. Leading dimensions are preserved, so both ``[N, F]``
+    and higher-rank inputs such as ``[N, T, F]`` are supported.
+    """
+
+    def __init__(
+        self,
+        in_features,
+        out_features,
+        branches=4,
+        top_k=2,
+        hidden_features=None,
+        bias=True,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        if branches < 1:
+            raise ValueError("branches must be at least 1")
+        if not 1 <= top_k <= branches:
+            raise ValueError("top_k must be between 1 and branches")
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.branches = branches
+        self.top_k = top_k
+        if hidden_features is None:
+            hidden_features = max(in_features, out_features)
+        elif hidden_features < 1:
+            raise ValueError("hidden_features must be at least 1")
+        self.hidden_features = hidden_features
+        self.use_bias = bias
+
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.router = nn.Linear(in_features, branches, **factory_kwargs)
+        self.specialists = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(
+                        in_features, self.hidden_features, bias=bias, **factory_kwargs
+                    ),
+                    nn.GELU(),
+                    nn.Linear(
+                        self.hidden_features, out_features, bias=bias, **factory_kwargs
+                    ),
+                )
+                for _ in range(branches)
+            ]
+        )
+        self.post_projection = nn.Linear(
+            out_features, out_features, bias=bias, **factory_kwargs
+        )
+        if in_features == out_features:
+            self.residual_projection = nn.Identity()
+        else:
+            self.residual_projection = nn.Linear(
+                in_features, out_features, bias=False, **factory_kwargs
+            )
+        self.activation = nn.GELU()
+        self.last_router_probabilities = None  # type: Optional[torch.Tensor]
+        self.last_sparse_weights = None  # type: Optional[torch.Tensor]
+
+    def forward(self, inputs):
+        probabilities = self.router(inputs).softmax(dim=-1)
+        top_values, top_indices = probabilities.topk(self.top_k, dim=-1)
+        sparse_weights = torch.zeros_like(probabilities).scatter(
+            -1, top_indices, top_values
+        )
+        sparse_weights = sparse_weights / sparse_weights.sum(
+            dim=-1, keepdim=True
+        ).clamp_min(1e-8)
+
+        specialist_outputs = torch.stack(
+            [specialist(inputs) for specialist in self.specialists], dim=-2
+        )
+        mixed = torch.sum(specialist_outputs * sparse_weights.unsqueeze(-1), dim=-2)
+        self.last_router_probabilities = probabilities
+        self.last_sparse_weights = sparse_weights
+        residual = self.residual_projection(inputs)
+        return self.activation(self.post_projection(mixed) + residual)
+
+    def balance_loss(self):
+        """Return a differentiable penalty for unequal soft branch usage."""
+        if self.last_router_probabilities is None:
+            return self.router.weight.new_zeros(())
+        reduce_dimensions = tuple(range(self.last_router_probabilities.ndim - 1))
+        utilization = self.last_router_probabilities.mean(dim=reduce_dimensions)
+        target = torch.full_like(utilization, 1.0 / self.branches)
+        return self.branches * (utilization - target).square().sum()
+
+    def routing_metrics(self):
+        """Return detached routing diagnostics from the most recent forward pass."""
+        if self.last_router_probabilities is None:
+            return {}
+        probabilities = self.last_router_probabilities.detach().clamp_min(1e-8)
+        reduce_dimensions = tuple(range(probabilities.ndim - 1))
+        utilization = probabilities.mean(dim=reduce_dimensions)
+        entropy = -(probabilities * probabilities.log()).sum(dim=-1).mean()
+        return {
+            "router_entropy": float(entropy),
+            "min_branch_utilization": float(utilization.min()),
+            "max_branch_utilization": float(utilization.max()),
+        }
+
+
+def create_dendritron_dendrite(
+    original_module, branches=4, top_k=2, hidden_features=None
+):
+    """Create a Dendritron candidate compatible with a linear parent module."""
+    if isinstance(original_module, DendritronLinear):
+        return DendritronLinear(
+            original_module.in_features,
+            original_module.out_features,
+            branches=original_module.branches,
+            top_k=original_module.top_k,
+            hidden_features=original_module.hidden_features,
+            bias=original_module.use_bias,
+            device=original_module.router.weight.device,
+            dtype=original_module.router.weight.dtype,
+        )
+    if not isinstance(original_module, nn.Linear):
+        raise TypeError(
+            "create_dendritron_dendrite expected nn.Linear or "
+            "DendritronLinear, got %s" % type(original_module).__name__
+        )
+    return DendritronLinear(
+        original_module.in_features,
+        original_module.out_features,
+        branches=branches,
+        top_k=top_k,
+        hidden_features=hidden_features,
+        bias=original_module.bias is not None,
+        device=original_module.weight.device,
+        dtype=original_module.weight.dtype,
+    )
+
+
+def initialize_variant_dendrite(branches=4, top_k=2, hidden_features=None):
+    """Register Dendritron creation for every currently perforated module.
+
+    Call this after ``UPA.perforate_model``. Restrict perforation to ``Linear``
+    modules before wrapping the model because this variant intentionally does
+    not create candidates for convolutional or other module types.
+    """
+    create_fn = partial(
+        create_dendritron_dendrite,
+        branches=branches,
+        top_k=top_k,
+        hidden_features=hidden_features,
+    )
+    GPA.pai_tracker.set_create_dendrite_global(create_fn)

--- a/dendrite_variants/dendritron/test_dendritron.py
+++ b/dendrite_variants/dendritron/test_dendritron.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest import mock
+
+import torch
+import torch.nn as nn
+
+from dendrite_variants.dendritron import dendritron
+
+
+class DendritronVariantTests(unittest.TestCase):
+    def test_linear_parent_produces_matching_multidimensional_output(self):
+        parent = nn.Linear(7, 5, bias=False).to(dtype=torch.float64)
+        candidate = dendritron.create_dendritron_dendrite(parent)
+        inputs = torch.randn(3, 4, 7, dtype=torch.float64, requires_grad=True)
+
+        output = candidate(inputs)
+        output.square().mean().backward()
+
+        self.assertEqual(output.shape, (3, 4, 5))
+        self.assertEqual(candidate.router.weight.dtype, parent.weight.dtype)
+        self.assertIsNotNone(inputs.grad)
+        self.assertIsNotNone(candidate.router.weight.grad)
+
+    def test_routing_keeps_exactly_top_k_specialists(self):
+        candidate = dendritron.DendritronLinear(8, 8, branches=4, top_k=2)
+        candidate(torch.randn(6, 8))
+
+        nonzero = (candidate.last_sparse_weights > 0).sum(dim=-1)
+        self.assertTrue(torch.equal(nonzero, torch.full_like(nonzero, 2)))
+        self.assertTrue(
+            torch.allclose(candidate.last_sparse_weights.sum(dim=-1), torch.ones(6))
+        )
+
+    def test_factory_recreates_platform_best_candidate_configuration(self):
+        candidate = dendritron.DendritronLinear(
+            9, 6, branches=5, top_k=3, hidden_features=11, bias=False
+        )
+
+        recreated = dendritron.create_dendritron_dendrite(candidate)
+
+        self.assertEqual(recreated.in_features, 9)
+        self.assertEqual(recreated.out_features, 6)
+        self.assertEqual(recreated.branches, 5)
+        self.assertEqual(recreated.top_k, 3)
+        self.assertEqual(recreated.hidden_features, 11)
+        self.assertFalse(recreated.use_bias)
+
+    def test_initializer_registers_a_configured_factory(self):
+        tracker = mock.Mock()
+        with mock.patch.object(dendritron.GPA, "pai_tracker", tracker):
+            dendritron.initialize_variant_dendrite(
+                branches=3, top_k=1, hidden_features=12
+            )
+
+        create_fn = tracker.set_create_dendrite_global.call_args.args[0]
+        candidate = create_fn(nn.Linear(4, 2))
+        self.assertEqual(candidate.branches, 3)
+        self.assertEqual(candidate.top_k, 1)
+        self.assertEqual(candidate.hidden_features, 12)
+
+    def test_factory_rejects_non_linear_modules(self):
+        with self.assertRaises(TypeError):
+            dendritron.create_dendritron_dendrite(nn.Conv2d(1, 2, 3))
+
+    def test_constructor_rejects_invalid_routing_configuration(self):
+        with self.assertRaises(ValueError):
+            dendritron.DendritronLinear(4, 4, branches=2, top_k=3)
+        with self.assertRaises(ValueError):
+            dendritron.DendritronLinear(4, 4, hidden_features=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dendrite_variants/dendritron/test_dendritron.py
+++ b/dendrite_variants/dendritron/test_dendritron.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 
 from dendrite_variants.dendritron import dendritron
+from perforatedai import modules_perforatedai as PA
 
 
 class DendritronVariantTests(unittest.TestCase):
@@ -67,6 +68,18 @@ class DendritronVariantTests(unittest.TestCase):
             dendritron.DendritronLinear(4, 4, branches=2, top_k=3)
         with self.assertRaises(ValueError):
             dendritron.DendritronLinear(4, 4, hidden_features=0)
+
+    def test_checkpoint_reconstruction_preserves_variant_factory(self):
+        tracker = mock.Mock()
+        tracker.member_vars = {"optimizer_instance": None}
+        with mock.patch.object(PA.GPA, "pai_tracker", tracker):
+            wrapped = PA.PAINeuronModule(nn.Linear(4, 4), ".test")
+        wrapped.set_create_dendrite(dendritron.create_dendritron_dendrite)
+
+        wrapped.clear_dendrites()
+        candidate = wrapped.dendrite_module.create_dendrite(wrapped.main_module)
+
+        self.assertIsInstance(candidate, dendritron.DendritronLinear)
 
 
 if __name__ == "__main__":

--- a/dendrite_variants/mnist_perforatedai_variant.py
+++ b/dendrite_variants/mnist_perforatedai_variant.py
@@ -121,6 +121,13 @@ def main():
     parser.add_argument("--save-name", type=str, default="PB")
     parser.add_argument("--dataset", type=str, default="MNIST")
     parser.add_argument(
+        "--variant",
+        type=str,
+        default="variant_framework",
+        choices=["variant_framework", "dendritron"],
+        help="dendrite variant to use (default: variant_framework)",
+    )
+    parser.add_argument(
         "--batch-size",
         type=int,
         default=64,
@@ -263,24 +270,46 @@ def main():
         test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
 
     # Set up some global parameters for PAI code
-    GPA.pc.set_testing_dendrite_capacity(False)
-    GPA.pc.set_neuron_grad_filter(True)
-    GPA.pc.set_verbose(False)
     model = Net(num_classes, args.width).to(device)
 
+    # Configure variant-specific settings
+    if args.variant == "variant_framework":
+        # GPA settings for variant_framework
+        GPA.pc.set_testing_dendrite_capacity(False)
+        GPA.pc.set_neuron_grad_filter(True)
+        GPA.pc.set_verbose(False)
 
-    # For the linear variant only perforate linear layers
-    GPA.pc.set_module_names_to_perforate(["Linear"])
-    GPA.pc.set_module_names_to_track(["Conv2d"])
+        # For the linear variant only perforate linear layers
+        GPA.pc.set_module_names_to_perforate(["Linear"])
+        GPA.pc.set_module_names_to_track(["Conv2d"])
 
-    # Perforate the model after setting up settings
-    model = UPA.perforate_model(model)
+        # Perforate the model after setting up settings
+        model = UPA.perforate_model(model)
 
-    print(GPA.pc.get_perforated_backpropagation()  )
+        print(GPA.pc.get_perforated_backpropagation())
 
-    # initialize_variant_dendrite must be called after perforate_model
-    import variant_framework.gradient_descent_linears as GDL
-    GDL.initialize_variant_dendrite()
+        # initialize_variant_dendrite must be called after perforate_model
+        import variant_framework.gradient_descent_linears as GDL
+        GDL.initialize_variant_dendrite()
+
+    elif args.variant == "dendritron":
+        # GPA settings for dendritron
+        GPA.pc.set_testing_dendrite_capacity(False)
+        GPA.pc.set_neuron_grad_filter(True)
+        GPA.pc.set_verbose(False)
+
+        # For the dendritron variant only perforate linear layers
+        GPA.pc.set_module_names_to_perforate(["Linear"])
+        GPA.pc.set_module_names_to_track(["Conv2d"])
+
+        # Perforate the model after setting up settings
+        model = UPA.perforate_model(model)
+
+        print(GPA.pc.get_perforated_backpropagation())
+
+        # initialize_variant_dendrite must be called after perforate_model
+        import dendritron.dendritron as dendritron
+        dendritron.initialize_variant_dendrite(branches=4, top_k=2, hidden_features=None)
 
     # Setup the optimizer and scheduler
     GPA.pai_tracker.set_optimizer(optim.Adadelta)

--- a/perforatedai/modules_perforatedai.py
+++ b/perforatedai/modules_perforatedai.py
@@ -525,6 +525,10 @@ class PAINeuronModule(nn.Module):
         None
 
         """
+        # Loading a saved state reconstructs PAIDendriteModule before simulating
+        # its saved cycles. Preserve a registered variant factory so candidate
+        # creation does not silently fall back to deep-copying the parent module.
+        create_dendrite_fn = self.dendrite_module._create_dendrite_fn
         self.dendrite_modules_added = 0
         self.dendrites_to_top = nn.ParameterList()
         self.candidate_to_top = nn.ParameterList()
@@ -534,6 +538,8 @@ class PAINeuronModule(nn.Module):
             name=self.name,
             output_dimensions=self.this_output_dimensions,
         )
+        if create_dendrite_fn is not None:
+            self.dendrite_module.set_create_dendrite(create_dendrite_fn)
 
     def __str__(self):
         """String representation of the module.


### PR DESCRIPTION
## What changed

- add a `dendrite_variants/dendritron` implementation with a four-specialist,
  top-2 sparse router, post-projection, residual path, and GELU activation
- preserve arbitrary leading tensor dimensions and support both square and
  non-square `nn.Linear` parents
- register the architecture through `initialize_variant_dendrite` while leaving
  the active PerforatedAI or Perforated Backpropagation learning rule unchanged
- preserve a registered variant factory when a `PAINeuronModule` reconstructs
  its dendrite module while loading saved state
- document checkout, installation, naming conventions, integration, and focused
  testing
- provide a reader-oriented Dendritron guide covering terminology, design
  intent, tensor flow, lifecycle, configuration, diagnostics, limitations,
  verification, and troubleshooting
- add focused tests for shapes, gradients, sparse routing, candidate recreation,
  registration, checkpoint reconstruction, and invalid inputs

## Why

The new dendrite-variant API allows candidate architecture customization
independently of the training rule. This contribution packages the tested
Dendritron routed-specialist topology as a reusable linear candidate while
respecting that separation.

Licensed end-to-end testing exposed a reconstruction bug: `clear_dendrites()`
created a fresh `PAIDendriteModule` without copying its registered candidate
factory, causing later candidates to silently fall back to the parent module
type. The factory is now retained across that reconstruction.

## User impact

Users can select linear modules for perforation, call
`initialize_variant_dendrite()` after `perforate_model`, and keep the remainder
of their optimizer and validation pipeline unchanged.

## Validation

- `python -m unittest dendrite_variants.dendritron.test_dendritron` - 7 tests
  passed
- Black formatting check passed
- Python byte-compilation passed
- documented Python examples parse and local Markdown links resolve
- `python -m pip install --no-deps -e .` passed
- PerforatedAI open-source candidate lifecycle smoke test created both candidate
  and best-candidate `DendritronLinear` modules
- licensed `perforatedbp==3.2.5` synthetic lifecycle test completed N -> P -> N,
  retained the Dendritron factory through three restructures, created candidate
  and best-candidate `DendritronLinear` modules, changed candidate parameters,
  and reached `training_complete`
- staged secret scan found no Perforated Backpropagation credentials

The licensed run is a mechanics/integration test on synthetic data, not evidence
of a production accuracy improvement. No credentials are stored in this branch
or the test harness.
